### PR TITLE
Generic procedure models + util functions

### DIFF
--- a/cmselemental/__init__.py
+++ b/cmselemental/__init__.py
@@ -1,2 +1,3 @@
 from . import util
 from . import models
+from . import types

--- a/cmselemental/extras.py
+++ b/cmselemental/extras.py
@@ -1,5 +1,3 @@
-import re
-
 from . import _version
 
 __all__ = ["get_information", "provenance_stamp"]
@@ -11,16 +9,16 @@ __info = {"version": versions["version"], "git_revision": versions["full-revisio
 
 def get_information(key):
     """
-    Obtains a variety of runtime information about QCEngine.
+    Obtains a variety of runtime information about CMSElemental.
     """
     key = key.lower()
     if key not in __info:
-        raise KeyError("Information key '{}' not understood.".format(key))
+        raise KeyError(f"Information key '{key}' not understood.")
 
     return __info[key]
 
 
-def provenance_stamp(creator, routine):
+def provenance_stamp(routine, creator="CMSElemental"):
     """Return dictionary satisfying QCSchema,
     https://github.com/MolSSI/QCSchema/blob/master/qcschema/dev/definitions.py#L23-L41
     with QCEngine's credentials for creator and version. The

--- a/cmselemental/models/__init__.py
+++ b/cmselemental/models/__init__.py
@@ -6,7 +6,6 @@ except ImportError:  # pragma: no cover
         "`conda install pydantic -c conda-forge` or `pip install pydantic`"
     )
 
-from . import types
 from .base import *
 from .common import *
 from .procedures import *

--- a/cmselemental/models/__init__.py
+++ b/cmselemental/models/__init__.py
@@ -1,3 +1,12 @@
-from . import base
+try:
+    import pydantic
+except ImportError:  # pragma: no cover
+    raise ImportError(
+        "Python module pydantic not found. Solve by installing it: "
+        "`conda install pydantic -c conda-forge` or `pip install pydantic`"
+    )
+
 from . import types
-from . import common
+from .base import *
+from .common import *
+from .procedures import *

--- a/cmselemental/models/base.py
+++ b/cmselemental/models/base.py
@@ -9,6 +9,8 @@ from ..testing import compare_recursive
 from ..util import deserialize, serialize
 from ..util.autodocs import AutoPydanticDocGenerator
 
+__all__ = ["ProtoModel", "AutodocBaseSettings"]
+
 
 def _repr(self) -> str:
     return f'{self.__repr_name__()}({self.__repr_str__(", ")})'

--- a/cmselemental/models/common.py
+++ b/cmselemental/models/common.py
@@ -9,9 +9,7 @@ from .base import ProtoModel, qcschema_draft
 if TYPE_CHECKING:
     from pydantic.typing import ReprArgs
 
-
-# Encoders, to be deprecated
-ndarray_encoder = {numpy.ndarray: lambda v: v.flatten().tolist()}
+__all__ = ["Provenance", "ComputeError", "FailedOperation"]
 
 
 class Provenance(ProtoModel):
@@ -36,22 +34,6 @@ class Provenance(ProtoModel):
 
         def schema_extra(schema, model):
             schema["$schema"] = qcschema_draft
-
-
-class DriverEnum(str, Enum):
-    """Allowed computation driver values."""
-
-    energy = "energy"
-    gradient = "gradient"
-    hessian = "hessian"
-    properties = "properties"
-
-    def derivative_int(self):
-        egh = ["energy", "gradient", "hessian", "third", "fourth", "fifth"]
-        if self == "properties":
-            return 0
-        else:
-            return egh.index(self)
 
 
 class ComputeError(ProtoModel):

--- a/cmselemental/models/procedures.py
+++ b/cmselemental/models/procedures.py
@@ -69,16 +69,13 @@ class ProcOutput(ProtoModel):
     stderr: Optional[str] = Field(
         None, description="The standard error of the program."
     )
-    warnings: Optional[str] = Field(
-        None, description="Warning messages."
-    )
+    warnings: Optional[str] = Field(None, description="Warning messages.")
     success: bool = Field(
         ...,
         description="The success of a given programs execution. If False, other fields may be blank.",
     )
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__doc__))
-    provenance: Optional[Provenance] = Field(..., description=str(Provenance.__doc__)
-    )
+    provenance: Optional[Provenance] = Field(..., description=str(Provenance.__doc__))
     extras: Optional[Dict[str, Any]] = Field(
         {}, description="Extra fields that are not part of the schema."
     )

--- a/cmselemental/models/procedures.py
+++ b/cmselemental/models/procedures.py
@@ -1,0 +1,78 @@
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from pydantic import Field, constr, validator
+
+from ..extras import provenance_stamp
+from .base import ProtoModel
+from .common import (
+    ComputeError,
+    Provenance,
+)
+
+cmsschema_proc_input_default = "cmsschema_proc_input"
+cmsschema_proc_output_default = "cmsschema_proc_output"
+
+__all__ = ["ProcInput", "ProcOutput"]
+
+
+class ProcInput(ProtoModel):
+    id: Optional[str] = None
+    hash_index: Optional[str] = None
+    schema_name: Optional[
+        constr(strip_whitespace=True, regex=cmsschema_proc_input_default)
+    ] = Field(  # type: ignore
+        cmsschema_proc_input_default,
+        description=(
+            f"The CMSSchema specification to which this model conforms. Explicitly fixed as {cmsschema_proc_input_default}."
+        ),
+    )
+    schema_version: Optional[int] = Field(  # type: ignore
+        0,
+        description="The version number of ``schema_name`` to which this model conforms.",
+    )
+    keywords: Optional[Dict[str, Any]] = Field(
+        {}, description="Procedure specific keywords to be used."
+    )
+    provenance: Optional[Provenance] = Field(
+        Provenance(**provenance_stamp(__name__)), description=str(Provenance.__doc__)
+    )
+    engine: Optional[str] = Field(
+        None,
+        description="Engine name to use in the procedure e.g. OpenMM.",
+    )
+    engine_version: Optional[str] = Field(
+        None, description="Supported engine version. e.g. '>=3.4.0'."
+    )
+    extras: Optional[Dict[str, Any]] = Field(
+        {}, description="Extra fields that are not part of the schema."
+    )
+
+
+class ProcOutput(ProtoModel):
+    proc_input: Optional[ProcInput] = None
+    schema_name: Optional[
+        constr(strip_whitespace=True, regex=cmsschema_proc_output_default)
+    ] = Field(  # type: ignore
+        cmsschema_proc_output_default,
+        description=(
+            f"The CMSSchema specification to which this model conforms. Explicitly fixed as {cmsschema_proc_output_default}."
+        ),
+    )
+    schema_version: Optional[int] = Field(  # type: ignore
+        0,
+        description="The version number of ``schema_name`` to which this model conforms.",
+    )
+    stdout: Optional[str] = Field(
+        None, description="The standard output of the program."
+    )
+    stderr: Optional[str] = Field(
+        None, description="The standard error of the program."
+    )
+
+    success: bool = Field(
+        ...,
+        description="The success of a given programs execution. If False, other fields may be blank.",
+    )
+    error: Optional[ComputeError] = Field(None, description=str(ComputeError.__doc__))
+    provenance: Provenance = Field(..., description=str(Provenance.__doc__))

--- a/cmselemental/models/procedures.py
+++ b/cmselemental/models/procedures.py
@@ -69,10 +69,16 @@ class ProcOutput(ProtoModel):
     stderr: Optional[str] = Field(
         None, description="The standard error of the program."
     )
-
+    warnings: Optional[str] = Field(
+        None, description="Warning messages."
+    )
     success: bool = Field(
         ...,
         description="The success of a given programs execution. If False, other fields may be blank.",
     )
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__doc__))
-    provenance: Provenance = Field(..., description=str(Provenance.__doc__))
+    provenance: Optional[Provenance] = Field(..., description=str(Provenance.__doc__)
+    )
+    extras: Optional[Dict[str, Any]] = Field(
+        {}, description="Extra fields that are not part of the schema."
+    )

--- a/cmselemental/tests/test_models.py
+++ b/cmselemental/tests/test_models.py
@@ -1,0 +1,74 @@
+import pytest
+
+from cmselemental.models import (
+    ComputeError,
+    FailedOperation,
+    ProcInput,
+    ProcOutput,
+    ProtoModel,
+    Provenance,
+)
+
+
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_repr_provenance(request):
+
+    prov = Provenance(creator="qcel", version="v0.3.2")
+    drop_qcsk(prov, request.node.name)
+
+    assert "qcel" in str(prov)
+    assert "qcel" in repr(prov)
+
+
+def test_repr_compute_error():
+    ce = ComputeError(error_type="random_error", error_message="this is bad")
+
+    assert "random_error" in str(ce)
+    assert "random_error" in repr(ce)
+
+
+def test_repr_failed_op():
+    fail_op = FailedOperation(
+        error=ComputeError(error_type="random_error", error_message="this is bad")
+    )
+    assert (
+        str(fail_op)
+        == """FailedOperation(error=ComputeError(error_type='random_error', error_message='this is bad'))"""
+    )
+
+
+def test_repr_optimization():
+
+    opt = ProcInput(
+        **{
+            "id": "some_id",
+            "engine": "some_engine",
+            "engine_version": "1.0.0",
+        }
+    )
+
+    assert "provenance" in str(opt)
+    assert "schema_name" in str(opt)
+    assert "schema_version" in str(opt)
+
+
+def test_model_custom_repr():
+    class Model(ProtoModel):
+        a: int
+
+        def __repr__(self) -> str:
+            return "Hello world!"
+
+    m = Model(a=5)
+    assert repr(m) == "Hello world!"
+    assert "Model(" in str(m)
+
+    class Model2(ProtoModel):
+        a: int
+
+        def __str__(self) -> str:
+            return "Hello world!"
+
+    m = Model2(a=5)
+    assert "Model2(" in repr(m)
+    assert str(m) == "Hello world!"

--- a/cmselemental/tests/test_models.py
+++ b/cmselemental/tests/test_models.py
@@ -37,13 +37,28 @@ def test_repr_failed_op():
     )
 
 
-def test_repr_optimization():
+def test_repr_proc_input():
 
     opt = ProcInput(
         **{
             "id": "some_id",
             "engine": "some_engine",
             "engine_version": "1.0.0",
+        }
+    )
+
+    assert "provenance" in str(opt)
+    assert "schema_name" in str(opt)
+    assert "schema_version" in str(opt)
+
+
+def test_repr_proc_output():
+
+    opt = ProcOutput(
+        **{
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "success": False,
         }
     )
 

--- a/cmselemental/tests/test_models.py
+++ b/cmselemental/tests/test_models.py
@@ -13,11 +13,11 @@ from cmselemental.models import (
 @pytest.mark.skip(reason="no way of currently testing this")
 def test_repr_provenance(request):
 
-    prov = Provenance(creator="qcel", version="v0.3.2")
+    prov = Provenance(creator="cmsel", version="v0.3.2")
     drop_qcsk(prov, request.node.name)
 
-    assert "qcel" in str(prov)
-    assert "qcel" in repr(prov)
+    assert "cmsel" in str(prov)
+    assert "cmsel" in repr(prov)
 
 
 def test_repr_compute_error():

--- a/cmselemental/tests/test_models_qc.py
+++ b/cmselemental/tests/test_models_qc.py
@@ -1,0 +1,35 @@
+import pytest
+import cmselemental
+
+qcel_found = cmselemental.util.importing.which_import("qcelemental")
+
+
+@pytest.mark.skipif(not qcel_found, reason="qcelemental not installed")
+def test_optim_qcel():
+    from qcelemental.models.procedures import (
+        OptimizationProtocols,
+        QCInputSpecification,
+    )
+    from qcelemental.models import Molecule
+
+    class OptimizationInput(cmselemental.models.ProcInput):
+
+        protocols: OptimizationProtocols = OptimizationProtocols()
+        input_specification: QCInputSpecification = ...
+        initial_molecule: Molecule = ...
+
+        def __repr_args__(self) -> "ReprArgs":
+            return [
+                ("model", self.input_specification.model.dict()),
+                ("molecule_hash", self.initial_molecule.get_hash()[:7]),
+            ]
+
+    opt = OptimizationInput(
+        **{
+            "input_specification": {"driver": "gradient", "model": {"method": "UFF"}},
+            "initial_molecule": {"symbols": ["He"], "geometry": [0, 0, 0]},
+        }
+    )
+
+    assert "molecule_hash" in str(opt)
+    assert "molecule_hash" in repr(opt)

--- a/cmselemental/types.py
+++ b/cmselemental/types.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict
 import numpy
 
+__all__ = ["Array"]
+
 
 class TypedArray(numpy.ndarray):
     @classmethod

--- a/cmselemental/util/__init__.py
+++ b/cmselemental/util/__init__.py
@@ -3,3 +3,4 @@ from . import importing
 from . import serialization
 from .serialization import serialize, deserialize
 from . import autodocs
+from . import files

--- a/cmselemental/util/autodocs.py
+++ b/cmselemental/util/autodocs.py
@@ -252,7 +252,7 @@ def auto_gen_docs_on_demand(
     ignore_reapply: bool = True,
     force_reapply: bool = False,
 ):
-    """Tell a Pydantic base model to generate its docstrings on the fly with the tech here """
+    """Tell a Pydantic base model to generate its docstrings on the fly with the tech here"""
     try:
         target.__doc__ = AutoPydanticDocGenerator(target, allow_failure=allow_failure)  # type: ignore
     except AutoDocError:

--- a/cmselemental/util/files.py
+++ b/cmselemental/util/files.py
@@ -1,0 +1,32 @@
+import uuid
+from pathlib import Path
+
+
+def random_file(suffix="", *, path=".", unique=True):
+    """Returns a random file name generated from a universally
+    unique identifier (UUID).
+
+    Parameters
+    ----------
+    suffix: str
+        Filename suffix
+    path: str
+        Path to filename
+    unique: bool
+        Ensures filename does not exist on disk
+    Return
+    ------
+    filename: str
+        Absolute filename path
+    """
+    fname = str(uuid.uuid4()) + suffix
+    fpath = Path(fname)
+
+    if path:
+        fpath = Path(path) / fpath
+
+    if unique:
+        if fpath.is_file():
+            return random_file(suffix, path=path, unique=unique)
+
+    return str(fpath.absolute())

--- a/cmselemental/util/importing.py
+++ b/cmselemental/util/importing.py
@@ -1,7 +1,43 @@
 import os
 import shutil
 import sys
-from typing import List, Union
+from typing import List, Union, Callable
+import warnings
+import functools
+import importlib
+
+
+def require(pkg_name) -> Callable:
+    """Returns a decorator function, ensures pkg_name is available and can be imported.
+    Parameters
+    ----------
+    pkg_name: str
+        Name of the package required.
+    Returns
+    -------
+    deco_require: Callable
+        Decorator function
+    Raises
+    ------
+    ModuleNotFoundError
+        When pkg_name is not found.
+    Example:
+    --------
+    @require("some_pkg")
+    def foo(...):
+        ...
+    """
+
+    def deco_require(func):
+        @functools.wraps(func)
+        def inner_func(*args, **kwargs):
+            if not which_import(pkg_name, return_bool=True):
+                raise ModuleNotFoundError(f"Could not find or import {pkg_name}.")
+            return func(*args, **kwargs)
+
+        return inner_func
+
+    return deco_require
 
 
 def which_import(


### PR DESCRIPTION
This PR:
- Extracts generic models from qcel/mmel for defining procedure input/output models
- Adds gen-purpose util functions
- Adds basic pytest routines

The procedure models should serve a superclasses for  qcel e.g. for `qcel.OptimizationInput` model shown below:

```python

from cmselemental.models import ProcInput

class OptimizationInput(ProcInput):

    protocols: OptimizationProtocols = Field(OptimizationProtocols(), description=str(OptimizationProtocols.__doc__))

    input_specification: QCInputSpecification = Field(..., description=str(QCInputSpecification.__doc__))
    initial_molecule: Molecule = Field(..., description="The starting molecule for the geometry optimization.")

    def __repr_args__(self) -> "ReprArgs":
        return [
            ("model", self.input_specification.model.dict()),
            ("molecule_hash", self.initial_molecule.get_hash()[:7]),
        ]    
```