### PR TITLE
Add support for storing log data in ProcOutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - ([`:pr:4`](https://github.com/MolSSI/cmselemental/pull/4) Add serialization support for YAML
 - ([`:pr:5`](https://github.com/MolSSI/cmselemental/pull/5) Add support for writing, reading. and converting `ProtoModel` to/from HDF5 based on the [HDF5/JSON](https://hdf5-json.readthedocs.io) specification. Add `$schema` keyword to the generated `ProtoModel` schema.
+- ([`:pr:6`](https://github.com/MolSSI/cmselemental/pull/6) Add support for storing log text to ProcOutput and transform __repr__ and __str__ to instant methods in ProtoModel.

--- a/cmselemental/models/base.py
+++ b/cmselemental/models/base.py
@@ -14,10 +14,6 @@ cmsschema_draft = "http://json-schema.org/draft-07/schema#"
 __all__ = ["ProtoModel", "AutodocBaseSettings"]
 
 
-def _repr(self) -> str:
-    return f'{self.__repr_name__()}({self.__repr_str__(", ")})'
-
-
 class ProtoModel(BaseModel):
     class Config:
         allow_mutation: bool = False
@@ -35,11 +31,11 @@ class ProtoModel(BaseModel):
         super().__init_subclass__(**kwargs)
         cls.__doc__ = AutoPydanticDocGenerator(cls, always_apply=True)
 
-        if "pydantic" in cls.__repr__.__module__:
-            cls.__repr__ = _repr
+    def __repr__(self):
+        return f'{self.__repr_name__()}({self.__repr_str__(", ")})'
 
-        if "pydantic" in cls.__str__.__module__:
-            cls.__str__ = _repr
+    def __str__(self):
+        return f'{self.__repr_name__()}({self.__repr_str__(", ")})'
 
     @classmethod
     def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> "ProtoModel":  # type: ignore

--- a/cmselemental/models/procedures.py
+++ b/cmselemental/models/procedures.py
@@ -57,6 +57,7 @@ class ProcOutput(ProtoModel):
         None, description="The standard error of the program."
     )
     warnings: Optional[str] = Field(None, description="Warning messages.")
+    log: Optional[str] = Field(None, description="Logging info.")
     success: bool = Field(
         ...,
         description="The success of a given programs execution. If False, other fields may be blank.",

--- a/cmselemental/util/importing.py
+++ b/cmselemental/util/importing.py
@@ -171,7 +171,6 @@ def yaml_import(raise_error: bool = False) -> ModuleType:
     ModuleNotFoundError
         When `raise_error=True` and module not found. Raises generic message plus `raise_msg`.
     """
-    from importlib import import_module
 
     raise_msg = "PyYAML or ruamel.yaml is required. Solve by installing either: `pip install pyyaml` or `pip install ruamel.yaml`"
 
@@ -180,7 +179,7 @@ def yaml_import(raise_error: bool = False) -> ModuleType:
         raise_error=False,
         return_bool=True,
     ):
-        return import_module("yaml")
+        return importlib.import_module("yaml")
     elif which_import("ruamel.yaml", raise_error=raise_error, raise_msg=raise_msg):
-        return import_module("ruamel.yaml")
+        return importlib.import_module("ruamel.yaml")
     return None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Minor update to the `ProcOutput` schema.

## Changelog description
- Add support for storing logging text to `ProcOutput`
- Transform `__repr__` and `__str__` to instant methods in `ProtoModel`.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
