### PR TITLE
Update to proc model names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - ([`:pr:6`])(https://github.com/MolSSI/cmselemental/pull/6) Add support for storing logging data to ProcOutput and transform `__repr__` and `__str__` to instant methods in ProtoModel.
 - ([`:pr:7`])(https://github.com/MolSSI/cmselemental/pull/7) Add a new (classproperty) method to `ProtoModel`: `default_schema_name`.
 - ([`:pr:8`])(https://github.com/MolSSI/cmselemental/pull/8) Create a decorators (util.decorators) submodule. Remove util.files submodule.
+- ([`:pr:9`])(https://github.com/MolSSI/cmselemental/pull/9) Rename `ProcInput` and `ProcOutput` to `InputProc` and `OutputProc`.

--- a/cmselemental/models/procedures.py
+++ b/cmselemental/models/procedures.py
@@ -8,10 +8,10 @@ from .common import (
     Provenance,
 )
 
-__all__ = ["ProcInput", "ProcOutput"]
+__all__ = ["InputProc", "OutputProc"]
 
 
-class ProcInput(ProtoModel):
+class InputProc(ProtoModel):
     id: Optional[str] = None
     hash_index: Optional[str] = None
     schema_name: str = Field(  # type: ignore
@@ -40,8 +40,8 @@ class ProcInput(ProtoModel):
     )
 
 
-class ProcOutput(ProtoModel):
-    proc_input: Optional[ProcInput] = None
+class OutputProc(ProtoModel):
+    proc_input: Optional[InputProc] = None
     schema_name: str = Field(  # type: ignore
         ...,
         description=("The schema specification to which this model conforms."),

--- a/cmselemental/tests/test_models.py
+++ b/cmselemental/tests/test_models.py
@@ -3,8 +3,8 @@ import pytest
 from cmselemental.models import (
     ComputeError,
     FailedOperation,
-    ProcInput,
-    ProcOutput,
+    InputProc,
+    OutputProc,
     ProtoModel,
     Provenance,
 )
@@ -39,7 +39,7 @@ def test_repr_failed_op():
 
 def test_repr_proc_input():
 
-    opt = ProcInput(
+    opt = InputProc(
         **{
             "schema_name": "some_schema",
             "schema_version": 2,
@@ -56,7 +56,7 @@ def test_repr_proc_input():
 
 def test_repr_proc_output():
 
-    opt = ProcOutput(
+    opt = OutputProc(
         **{
             "schema_name": "my_schema",
             "schema_version": 1,

--- a/cmselemental/tests/test_models_qc.py
+++ b/cmselemental/tests/test_models_qc.py
@@ -12,7 +12,7 @@ def test_optim_qcel():
     )
     from qcelemental.models import Molecule
 
-    class OptimizationInput(cmselemental.models.ProcInput):
+    class OptimizationInput(cmselemental.models.InputProc):
 
         schema_name: str = "qcschema"
         schema_version: int = 2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->


## Changelog description
- Rename `ProcInput` and `ProcOutput` to `InputProc` and `OutputProc` for improved findability.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
